### PR TITLE
Add missing unit tests

### DIFF
--- a/tests/test_excel_sorter.py
+++ b/tests/test_excel_sorter.py
@@ -1,6 +1,8 @@
 import os
 import ast
 import re
+import importlib
+import sys
 
 
 def load_function(file_path, func_name):
@@ -26,4 +28,28 @@ def test_separateNumbersAlphabets():
     ns["separateNumbersAlphabets"]("ABC123")
     assert ns["numbers"] == ["123"]
     assert ns["alphabets"] == ["ABC"]
+
+
+def test_install_and_import(monkeypatch):
+    file_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "excel_sorter.py")
+    ns = load_function(file_path, "install_and_import")
+
+    calls = {"pip": None, "imports": []}
+
+    def fake_import_module(name):
+        calls["imports"].append(name)
+        if len(calls["imports"]) == 1:
+            raise ImportError
+        return f"module-{name}"
+
+    def fake_pip_main(args):
+        calls["pip"] = args
+
+    monkeypatch.setattr(importlib, "import_module", fake_import_module)
+    monkeypatch.setitem(sys.modules, "pip", type("pipmod", (), {"main": fake_pip_main}))
+
+    ns["install_and_import"]("mypkg")
+
+    assert calls["pip"] == ["install", "mypkg"]
+    assert ns["mypkg"] == "module-mypkg"
 


### PR DESCRIPTION
## Summary
- expand test coverage by testing the `install_and_import` helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68485f67e284832797f5caae1b85e588